### PR TITLE
Handling out-of-memory problems with the memory cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,13 @@ use Illuminate\Support\Facades\Cache;
 
 $data = Cache::store('memory')->get('some_key');
 ```
+
+## About memory limits
+Garbage collection (by removing expired items) will be performed when the cache is near the size limit.
+If the garbage collection fails to reduce the size of the cache below the size limit,
+then the cache will be invalidated and the underlying memory segment is marked for deletion. 
+
+Note: **items that are stored as "forever" may be removed when the cache reaches its size limit**.
+
+### Recreating the memory block
+When recreating the memory block, the newest size limit defined in the Laravel config file will be used.

--- a/README.md
+++ b/README.md
@@ -67,9 +67,23 @@ $data = Cache::store('memory')->get('some_key');
 ## About memory limits
 Garbage collection (by removing expired items) will be performed when the cache is near the size limit.
 If the garbage collection fails to reduce the size of the cache below the size limit,
-then the cache will be invalidated and the underlying memory segment is marked for deletion. 
+then the cache will be invalidated and the underlying memory segment is marked for deletion.
+
+Running out of memory will generate a warning or a notice in your logs, no matter if it is resolved by
+a garbage collection or by segment deletion.
 
 Note: **items that are stored as "forever" may be removed when the cache reaches its size limit**.
 
 ### Recreating the memory block
 When recreating the memory block, the newest size limit defined in the Laravel config file will be used.
+
+### Manually marking the memory segment for deletion
+There are use cases to this, such as wanting to refresh the memory block now instead of waiting for 
+another "out of memory" event. In this case, you may do the following:
+
+```php
+// the deletion will be managed by the OS kernel , and will happen at a future time
+Cache::store('memory')->getStore()->requestDeletion();
+```
+
+This usage will not trigger any warnings or notices since this is an action taken deliberately.

--- a/src/Cache/MemoryBlock.php
+++ b/src/Cache/MemoryBlock.php
@@ -207,9 +207,9 @@ class MemoryBlock
      * Note that this is the size of the actual memory block managed by the OS kernel.
      *
      * This size can be different from the size obtained from getSize().
-     * When the specified memory size is updated by the user, 
+     * When the specified memory size is updated by the user,
      * the OS must delete and recreate the memory block so that the new size can be applied.
-     * 
+     *
      * @return int
      */
     public function getSizeInMemory()

--- a/src/Cache/MemoryBlock.php
+++ b/src/Cache/MemoryBlock.php
@@ -189,11 +189,32 @@ class MemoryBlock
     /**
      * Gets the current shared memory size.
      *
+     * Note that this is the size specified by the user.
+     *
+     * This size can be different from the size obtained from getSizeInMemory()
+     * because, e.g., the user has changed the size limit but the change is not yet communicated to the OS kernel.
+     *
      * @return int
      */
     public function getSize()
     {
         return $this->size;
+    }
+
+    /**
+     * Gets the current shared memory size.
+     *
+     * Note that this is the size of the actual memory block managed by the OS kernel.
+     *
+     * This size can be different from the size obtained from getSize().
+     * When the specified memory size is updated by the user, 
+     * the OS must delete and recreate the memory block so that the new size can be applied.
+     * 
+     * @return int
+     */
+    public function getSizeInMemory()
+    {
+        return shmop_size($this->id);
     }
 
     /**

--- a/src/Cache/MemoryStore.php
+++ b/src/Cache/MemoryStore.php
@@ -191,14 +191,18 @@ class MemoryStore implements StoreInterface
                 }
             }
 
+            $message = "Laravel Memory Cache: Out of memory (Unix allocated $memorySize); ";
+
             $serial = (string) $this->serialize($data);
 
             if (strlen($serial) > $memorySize) {
-                trigger_error("Laravel Memory Cache: Out of memory (Unix allocated $memorySize); the segment will be recreated.", E_USER_WARNING);
+                $message .= 'the segment will be recreated.';
+                trigger_error($message, E_USER_WARNING);
 
                 $this->memory->delete();
             } else {
-                trigger_error("Laravel Memory Cache: Out of memory (Unix allocated $memorySize); garbage collection was performed.", E_USER_NOTICE);
+                $message .= 'garbage collection was performed.';
+                trigger_error($message, E_USER_NOTICE);
             }
         }
 

--- a/src/Cache/MemoryStore.php
+++ b/src/Cache/MemoryStore.php
@@ -276,4 +276,19 @@ class MemoryStore implements StoreInterface
     {
         return is_numeric($value) ? $value : @unserialize($value);
     }
+
+    /**
+     * Requests to the OS kernel that the underlying shared memory segment should be deleted.
+     *
+     * This allows the memory segment to be recreated later with updated parameters.
+     *
+     * The timing of deletion is managed by the OS kernel, but this usually happens after
+     * all relevant processes are disconnected from the shared memory segment.
+     *
+     * @return void
+     */
+    public function requestDeletion()
+    {
+        $this->memory->delete();
+    }
 }


### PR DESCRIPTION
This mainly targets #6, but can also be used to deal with #5.

- Will do a GC when memory is running low
- Will recycle memory block if running out of space
- Provides option for users to recycle the memory block